### PR TITLE
Feature/draft blog preview

### DIFF
--- a/src/app/_components/draft-blog.tsx
+++ b/src/app/_components/draft-blog.tsx
@@ -1,0 +1,104 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import { PulseResponse } from "@/lib/pulse-client"
+
+/**
+ * DraftBlog
+ *
+ * Renders an AI-generated blog draft progressively (ChatGPT-style fade-in).
+ * This is meant to be a private preview before publishing.
+ *
+ * Props:
+ * - data: PulseResponse (title, summary, news, meaning, etc.)
+ */
+export default function DraftBlog({ data }: { data: PulseResponse }) {
+  const [step, setStep] = useState(0)
+
+  // Progressive reveal of blog sections (1 per second)
+  useEffect(() => {
+    const timers = [
+      setTimeout(() => setStep(1), 1000),
+      setTimeout(() => setStep(2), 2000),
+      setTimeout(() => setStep(3), 3000),
+      setTimeout(() => setStep(4), 4000),
+      setTimeout(() => setStep(5), 5000),
+      setTimeout(() => setStep(6), 6000),
+      setTimeout(() => setStep(7), 7000),
+      setTimeout(() => setStep(8), 8000),
+    ]
+    return () => timers.forEach(clearTimeout)
+  }, [])
+
+  return (
+    <article className="space-y-6 max-w-3xl mx-auto">
+      {/* Blog title */}
+      <h1 className="text-4xl font-bold">{data.title || "Draft title"}</h1>
+
+      {/* Blog summary */}
+      <p className="text-lg text-gray-700">{data.summary || "Draft summary"}</p>
+
+      {/* Sections appear progressively */}
+      {step >= 1 && (
+        <section className="animate-fadeIn">
+          <h3 className="text-xl font-semibold mb-2">📰 News</h3>
+          <p>{data.news}</p>
+        </section>
+      )}
+
+      {step >= 2 && (
+        <section className="animate-fadeIn">
+          <h3 className="text-xl font-semibold mb-2">💡 Meaning</h3>
+          <p>{data.meaning}</p>
+        </section>
+      )}
+
+      {step >= 3 && (
+        <section className="animate-fadeIn">
+          <h3 className="text-xl font-semibold mb-2">⚡ Action</h3>
+          <p>{data.action}</p>
+        </section>
+      )}
+
+      {step >= 4 && (
+        <section className="animate-fadeIn">
+          <h3 className="text-xl font-semibold mb-2">🔗 LinkedIn</h3>
+          <p>{data.linkedin_post}</p>
+        </section>
+      )}
+
+      {step >= 5 && (
+        <section className="animate-fadeIn">
+          <h3 className="text-xl font-semibold mb-2">🛠️ POCs</h3>
+          <p>{data.poc_ideas}</p>
+        </section>
+      )}
+
+      {step >= 6 && (
+        <section className="animate-fadeIn">
+          <h3 className="text-xl font-semibold mb-2">📈 Compounding</h3>
+          <p>{data.compounding}</p>
+        </section>
+      )}
+
+      {step >= 7 && (
+        <section className="animate-fadeIn">
+          <h3 className="text-xl font-semibold mb-2">📋 Final Summary</h3>
+          <p>{data.final_summary}</p>
+        </section>
+      )}
+
+      {/* Future publish button */}
+      {step >= 8 && (
+        <div className="mt-8">
+          <button
+            className="bg-green-600 text-white px-6 py-3 font-bold hover:bg-green-700 transition"
+            onClick={() => alert("TODO: Save as Markdown and publish")}
+          >
+            Publish this blog
+          </button>
+        </div>
+      )}
+    </article>
+  )
+}

--- a/src/app/_components/draft-blog.tsx
+++ b/src/app/_components/draft-blog.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from "react"
 import { PulseResponse } from "@/lib/pulse-client"
+import Header from "./header"
 
 /**
  * DraftBlog
@@ -13,92 +14,94 @@ import { PulseResponse } from "@/lib/pulse-client"
  * - data: PulseResponse (title, summary, news, meaning, etc.)
  */
 export default function DraftBlog({ data }: { data: PulseResponse }) {
-  const [step, setStep] = useState(0)
+    const [step, setStep] = useState(0)
 
-  // Progressive reveal of blog sections (1 per second)
-  useEffect(() => {
-    const timers = [
-      setTimeout(() => setStep(1), 1000),
-      setTimeout(() => setStep(2), 2000),
-      setTimeout(() => setStep(3), 3000),
-      setTimeout(() => setStep(4), 4000),
-      setTimeout(() => setStep(5), 5000),
-      setTimeout(() => setStep(6), 6000),
-      setTimeout(() => setStep(7), 7000),
-      setTimeout(() => setStep(8), 8000),
-    ]
-    return () => timers.forEach(clearTimeout)
-  }, [])
+    // Progressive reveal of blog sections (1 per second)
+    useEffect(() => {
+        const timers = [
+            setTimeout(() => setStep(1), 1000),
+            setTimeout(() => setStep(2), 2000),
+            setTimeout(() => setStep(3), 3000),
+            setTimeout(() => setStep(4), 4000),
+            setTimeout(() => setStep(5), 5000),
+            setTimeout(() => setStep(6), 6000),
+            setTimeout(() => setStep(7), 7000),
+            setTimeout(() => setStep(8), 8000),
+        ]
+        return () => timers.forEach(clearTimeout)
+    }, [])
 
-  return (
-    <article className="space-y-6 max-w-3xl mx-auto">
-      {/* Blog title */}
-      <h1 className="text-4xl font-bold">{data.title || "Draft title"}</h1>
+    return (<>
+        <Header />
+        <article className="space-y-6 max-w-3xl mx-auto">
+            {/* Blog title */}
+            <h1 className="text-4xl font-bold">{data.title || "Draft title"}</h1>
 
-      {/* Blog summary */}
-      <p className="text-lg text-gray-700">{data.summary || "Draft summary"}</p>
+            {/* Blog summary */}
+            <p className="text-lg text-gray-700">{data.summary || "Draft summary"}</p>
 
-      {/* Sections appear progressively */}
-      {step >= 1 && (
-        <section className="animate-fadeIn">
-          <h3 className="text-xl font-semibold mb-2">📰 News</h3>
-          <p>{data.news}</p>
-        </section>
-      )}
+            {/* Sections appear progressively */}
+            {step >= 1 && (
+                <section className="animate-fadeIn">
+                    <h3 className="text-xl font-semibold mb-2">📰 News</h3>
+                    <p>{data.news}</p>
+                </section>
+            )}
 
-      {step >= 2 && (
-        <section className="animate-fadeIn">
-          <h3 className="text-xl font-semibold mb-2">💡 Meaning</h3>
-          <p>{data.meaning}</p>
-        </section>
-      )}
+            {step >= 2 && (
+                <section className="animate-fadeIn">
+                    <h3 className="text-xl font-semibold mb-2">💡 Meaning</h3>
+                    <p>{data.meaning}</p>
+                </section>
+            )}
 
-      {step >= 3 && (
-        <section className="animate-fadeIn">
-          <h3 className="text-xl font-semibold mb-2">⚡ Action</h3>
-          <p>{data.action}</p>
-        </section>
-      )}
+            {step >= 3 && (
+                <section className="animate-fadeIn">
+                    <h3 className="text-xl font-semibold mb-2">⚡ Action</h3>
+                    <p>{data.action}</p>
+                </section>
+            )}
 
-      {step >= 4 && (
-        <section className="animate-fadeIn">
-          <h3 className="text-xl font-semibold mb-2">🔗 LinkedIn</h3>
-          <p>{data.linkedin_post}</p>
-        </section>
-      )}
+            {step >= 4 && (
+                <section className="animate-fadeIn">
+                    <h3 className="text-xl font-semibold mb-2">🔗 LinkedIn</h3>
+                    <p>{data.linkedin_post}</p>
+                </section>
+            )}
 
-      {step >= 5 && (
-        <section className="animate-fadeIn">
-          <h3 className="text-xl font-semibold mb-2">🛠️ POCs</h3>
-          <p>{data.poc_ideas}</p>
-        </section>
-      )}
+            {step >= 5 && (
+                <section className="animate-fadeIn">
+                    <h3 className="text-xl font-semibold mb-2">🛠️ POCs</h3>
+                    <p>{data.poc_ideas}</p>
+                </section>
+            )}
 
-      {step >= 6 && (
-        <section className="animate-fadeIn">
-          <h3 className="text-xl font-semibold mb-2">📈 Compounding</h3>
-          <p>{data.compounding}</p>
-        </section>
-      )}
+            {step >= 6 && (
+                <section className="animate-fadeIn">
+                    <h3 className="text-xl font-semibold mb-2">📈 Compounding</h3>
+                    <p>{data.compounding}</p>
+                </section>
+            )}
 
-      {step >= 7 && (
-        <section className="animate-fadeIn">
-          <h3 className="text-xl font-semibold mb-2">📋 Final Summary</h3>
-          <p>{data.final_summary}</p>
-        </section>
-      )}
+            {step >= 7 && (
+                <section className="animate-fadeIn">
+                    <h3 className="text-xl font-semibold mb-2">📋 Final Summary</h3>
+                    <p>{data.final_summary}</p>
+                </section>
+            )}
 
-      {/* Future publish button */}
-      {step >= 8 && (
-        <div className="mt-8">
-          <button
-            className="bg-green-600 text-white px-6 py-3 font-bold hover:bg-green-700 transition"
-            onClick={() => alert("TODO: Save as Markdown and publish")}
-          >
-            Publish this blog
-          </button>
-        </div>
-      )}
-    </article>
-  )
+            {/* Future publish button */}
+            {step >= 8 && (
+                <div className="mt-8">
+                    <button
+                        className="bg-green-600 text-white px-6 py-3 font-bold hover:bg-green-700 transition"
+                        onClick={() => alert("TODO: Save as Markdown and publish")}
+                    >
+                        Publish this blog
+                    </button>
+                </div>
+            )}
+        </article>
+    </>
+    )
 }

--- a/src/app/_components/draft-blog.tsx
+++ b/src/app/_components/draft-blog.tsx
@@ -32,7 +32,6 @@ export default function DraftBlog({ data }: { data: PulseResponse }) {
     }, [])
 
     return (<>
-        <Header />
         <article className="space-y-6 max-w-3xl mx-auto">
             {/* Blog title */}
             <h1 className="text-4xl font-bold">{data.title || "Draft title"}</h1>

--- a/src/app/_components/start-blog-form.tsx
+++ b/src/app/_components/start-blog-form.tsx
@@ -23,7 +23,7 @@ export default function StartBlogForm() {
   return (
     <section className="my-12">
       <h2 className="mb-4 text-5xl font-bold">
-        Create your Dynamic Blog
+        Crear blog dinámico
       </h2>
       <p className="mt-4 text-lg leading-relaxed mb-4">
         El que no escribe su historia, termina leyendo la de otros. Tú no...

--- a/src/app/_components/start-blog-form.tsx
+++ b/src/app/_components/start-blog-form.tsx
@@ -1,132 +1,63 @@
 "use client"
 
-import { fetchPulse, PulseResponse } from "@/lib/pulse-client";
-import { useState } from "react";
+import { useState } from "react"
+import { useRouter } from "next/navigation"
 
 export default function StartBlogForm() {
-  const [profession, setProfession] = useState("");
-  const [sector, setSector] = useState("");
+  const [profession, setProfession] = useState("")
+  const [sector, setSector] = useState("")
+  const [loading, setLoading] = useState(false)
+  const router = useRouter()
 
-  const [loading, setLoading] = useState(false);
-  const [result, setResult] = useState<PulseResponse | null>(null);
-
-  //* This prevents React from rendering nothing or crashing when optional fields from the API response are missing.
-  const safe = (value: string | null | undefined) =>
-    value && value.trim() !== "" ? value : "N/A"
-
-  const handleSubmit = async (e: React.FormEvent) => {
+  const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault()
     setLoading(true)
 
-    try {
-      const data = await fetchPulse({
-        lang: "es",
-        // TODO: make this dynamic (multilanguage support)
-        // Use standard i18n codes: "en", "es", "fr", etc.
-        // Option 1: detect browser language
-        // Option 2: add a language selector
+    const encodedProfession = encodeURIComponent(profession)
+    const encodedSector = encodeURIComponent(sector)
 
-        profession,
-        sector,
-      })
-      setResult(data)
-      console.log("✅ API response:", data)
-    } catch (error) {
-      console.error("❌ Error:", error)
-      setResult(null)
-    } finally {
-      setLoading(false)
-    }
+    // Redirect to draft page with params
+    router.push(`/draft?profession=${encodedProfession}&sector=${encodedSector}`)
   }
 
   return (
     <section className="my-12">
-      <div className="mb-8 border-t border-gray-300"></div>
-
-      <h2 className="mb-4 text-5xl font-bold tracking-tight">
-        Crea tu Blog Dinámico
+      <h2 className="mb-4 text-5xl font-bold">
+        Create your Dynamic Blog
       </h2>
-
       <p className="mt-4 text-lg leading-relaxed mb-4">
         El que no escribe su historia, termina leyendo la de otros. Tú no...
       </p>
-
-      {/* Formulario */}
       <form
         onSubmit={handleSubmit}
         className="flex flex-col gap-2 md:flex-row md:items-center md:gap-2"
       >
         <input
           id="profession"
-          className="flex-1 border p-2 rounded"
-          placeholder="Profesión (ej. Desarrollador)"
+          className="flex-1 border p-2"
+          placeholder="Profession (e.g., Developer)"
           value={profession}
           onChange={(e) => setProfession(e.target.value)}
           required
         />
+
         <input
           id="sector"
-          className="flex-1 border p-2 rounded"
-          placeholder="Sector (ej. AI, Finanzas, Salud)"
+          className="flex-1 border p-2"
+          placeholder="Sector (e.g., AI, Finance, Healthcare)"
           value={sector}
           onChange={(e) => setSector(e.target.value)}
           required
         />
+
         <button
           type="submit"
           disabled={loading}
-          className="w-full md:w-auto bg-black hover:bg-white hover:text-black border border-black text-white font-bold py-3 px-6 transition-colors duration-200 rounded"
+          className="w-full md:w-auto bg-black hover:bg-white hover:text-black border border-black text-white font-bold py-3 px-6 transition-colors duration-200"
         >
-          {loading ? "Generando..." : "Quiero dar el primer paso"}
+          {loading ? "Generando..." : "Generar"}
         </button>
       </form>
-
-      {/* Resultado */}
-      {result && (
-        <div className="mt-8 p-4 bg-gray-50 rounded shadow-sm whitespace-pre-wrap">
-          <h3 className="text-2xl font-semibold mb-2">
-            {safe(result.title)} {/* 👈 si no hay title, N/A */}
-          </h3>
-          <p className="text-gray-700 mb-4">
-            {safe(result.summary)} {/* 👈 si no hay summary, N/A */}
-          </p>
-
-          <div className="mb-4">
-            <h4 className="font-semibold">📰 Noticias:</h4>
-            <p>{safe(result.news)}</p>
-          </div>
-
-          <div className="mb-4">
-            <h4 className="font-semibold">💡 Oportunidades:</h4>
-            <p>{safe(result.meaning)}</p>
-          </div>
-
-          <div className="mb-4">
-            <h4 className="font-semibold">⚡ Acción diaria:</h4>
-            <p>{safe(result.action)}</p>
-          </div>
-
-          <div className="mb-4">
-            <h4 className="font-semibold">🔗 Post LinkedIn:</h4>
-            <p>{safe(result.linkedin_post)}</p>
-          </div>
-
-          <div className="mb-4">
-            <h4 className="font-semibold">🛠️ POCs:</h4>
-            <p>{safe(result.poc_ideas)}</p>
-          </div>
-
-          <div className="mb-4">
-            <h4 className="font-semibold">📈 Compounding:</h4>
-            <p>{safe(result.compounding)}</p>
-          </div>
-
-          <div>
-            <h4 className="font-semibold">📋 Resumen Final:</h4>
-            <p>{safe(result.final_summary)}</p>
-          </div>
-        </div>
-      )}
     </section>
-  );
+  )
 }

--- a/src/app/draft/loading.tsx
+++ b/src/app/draft/loading.tsx
@@ -1,0 +1,28 @@
+import Container from "../_components/container";
+import Header from "../_components/header";
+
+export default function LoadingDraft() {
+    return (
+        <Container>
+            <Header></Header>
+            <main className="py-12 max-w-3xl mx-auto animate-pulse">
+                {/* Title skeleton */}
+                <div className="h-8 bg-gray-200 rounded w-3/4 mb-4"></div>
+                {/* Summary skeleton */}
+                <div className="h-5 bg-gray-200 rounded w-5/6 mb-8"></div>
+
+                {/* Sections skeleton */}
+                <div className="space-y-6">
+                    {[...Array(5)].map((_, i) => (
+                        <div key={i} className="space-y-2">
+                            <div className="h-5 bg-gray-300 rounded w-1/3"></div>
+                            <div className="h-4 bg-gray-200 rounded w-full"></div>
+                            <div className="h-4 bg-gray-200 rounded w-11/12"></div>
+                            <div className="h-4 bg-gray-200 rounded w-10/12"></div>
+                        </div>
+                    ))}
+                </div>
+            </main>
+        </Container>
+    )
+}

--- a/src/app/draft/page.tsx
+++ b/src/app/draft/page.tsx
@@ -1,0 +1,41 @@
+import { notFound } from "next/navigation"
+import DraftBlog from "../_components/draft-blog";
+import { PulseResponse } from "@/lib/pulse-client"
+
+export default async function DraftPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ profession?: string; sector?: string }>
+}) {
+  const sp = await searchParams
+  const profession = sp.profession
+  const sector = sp.sector
+
+  if (!profession || !sector) return notFound()
+
+  // Build absolute URL for server-side fetch
+  const baseUrl =
+    process.env.NEXT_PUBLIC_APP_URL || "http://localhost:3000"
+
+  const res = await fetch(`${baseUrl}/api/pulse`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      task: "Daily briefing",
+      lang: "es", // TODO: support dynamic multilanguage
+      profession,
+      sector,
+    }),
+    cache: "no-store", // avoid stale data for drafts
+  })
+
+  if (!res.ok) return notFound()
+
+  const data: PulseResponse = await res.json()
+
+  return (
+    <main className="py-12">
+      <DraftBlog data={data} />
+    </main>
+  )
+}

--- a/src/app/draft/page.tsx
+++ b/src/app/draft/page.tsx
@@ -1,12 +1,15 @@
 import { notFound } from "next/navigation"
-import DraftBlog from "../_components/draft-blog";
+import DraftBlog from "../_components/draft-blog"
 import { PulseResponse } from "@/lib/pulse-client"
+import Container from "../_components/container";
+import Header from "../_components/header";
 
 export default async function DraftPage({
   searchParams,
 }: {
   searchParams: Promise<{ profession?: string; sector?: string }>
 }) {
+  // ✅ Await searchParams (required in Next.js 15)
   const sp = await searchParams
   const profession = sp.profession
   const sector = sp.sector
@@ -34,8 +37,11 @@ export default async function DraftPage({
   const data: PulseResponse = await res.json()
 
   return (
-    <main className="py-12">
-      <DraftBlog data={data} />
-    </main>
+    <Container>
+      <Header></Header>
+      <main className="py-12">
+        <DraftBlog data={data} />
+      </main>
+    </Container>
   )
 }

--- a/src/app/posts/[slug]/page.tsx
+++ b/src/app/posts/[slug]/page.tsx
@@ -21,7 +21,6 @@ export default async function Post(props: Params) {
 
   return (
     <main>
-      <Alert preview={post.preview} />
       <Container>
         <Header />
         <article className="mb-32">


### PR DESCRIPTION
🚀 feat(draft-blog-preview): progressive rendering flow for AI blog drafts

- Added `DraftBlog` component with step-by-step fade-in (ChatGPT-style reveal)
- Implemented `/draft` route with server-side fetch for Pulse API results
- Added loading skeleton (`loading.tsx`) for better UX while fetching
- Updated `StartBlogForm` to redirect with profession & sector params
- Simplified form copy and placeholders (multilanguage ready)
- Removed redundant header from `DraftBlog` (wrapped with `Container` & `Header` in page)