### PR TITLE
Hotfix: remove duplicate openGraph key in metadata

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -14,9 +14,6 @@ export const metadata: Metadata = {
   title: 'GrowRoutine — AI, hábitos y crecimiento sostenible',
   description: 'Tu fuente de inspiración diaria para crear disciplina, constancia y resultados. AI + hábitos + mindset.',
   openGraph: {
-    images: [HOME_OG_IMAGE_URL],
-  },
-  openGraph: {
     title: "GrowRoutine — Crece 1% cada día",
     description:
       "Tu fuente de inspiración diaria para crear disciplina, constancia y resultados. AI + hábitos + mindset.",


### PR DESCRIPTION
- Fixed compile error caused by repeated openGraph object in layout.tsx
- Ensured metadata includes full GrowRoutine branding without duplication